### PR TITLE
Fix for QuestDB with table dropping

### DIFF
--- a/tsbs-tests/tsbs_benchmarks.py
+++ b/tsbs-tests/tsbs_benchmarks.py
@@ -146,6 +146,7 @@ def load_data(main_file_path, db_engine, test_file, extra_commands = [], workers
         rows_list.append(int(round(float(extracted_floats[1]))))
         time_list.append(round(float(time_match[0]), 2))
 
+        # Runs a little bobby tables on the questdb database to maintain speed and keep RAM low-ish
         if db_engine == "questdb":
             for table in questdb_tables:
                 subprocess.run('curl -G --data-urlencode "query=DROP TABLE IF EXISTS ' + table + '" http://localhost:9000/exec', capture_output=True, shell=True)
@@ -224,6 +225,7 @@ def handle_args():
 
     args.seed = fix_args({"seed": args.seed})
 
+    # Checks if the timestamps exists and they look correct
     if args.timestamp_start is None or not re.findall(r"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ", args.timestamp_start):
         args.timestamp_start = "2025-05-01T00:00:00Z"
 
@@ -233,6 +235,18 @@ def handle_args():
     return args
 
 def fix_args(argument_dict):
+    """
+    Handles bad inputs on the int values and sets them to default values if not fixable
+
+    Parameters:
+        argument_dict : dict
+            A dict with the name of the argparse argument and its value
+    
+    Returns:
+        argument : int
+            Returns the fixed argument for the integers
+    """
+
     try:
         argument = int(list(argument_dict.values())[0])
     except:

--- a/tsbs-tests/tsbs_benchmarks.py
+++ b/tsbs-tests/tsbs_benchmarks.py
@@ -100,6 +100,8 @@ def load_data(main_file_path, db_engine, test_file, extra_commands = [], workers
     rows_list = []
     time_list = []
 
+    questdb_tables = ["cpu", "diagnostics", "disk", "diskio", "kernel", "mem", "net", "nginx", "postgresl", "readings", "redis"]
+
     print("Loading data for " + db_engine + " with file " + file_path + ":")
 
     for i in range(runs):
@@ -143,6 +145,10 @@ def load_data(main_file_path, db_engine, test_file, extra_commands = [], workers
         metrics_list.append(int(round(float(extracted_floats[0]))))
         rows_list.append(int(round(float(extracted_floats[1]))))
         time_list.append(round(float(time_match[0]), 2))
+
+        if db_engine == "questdb":
+            for table in questdb_tables:
+                subprocess.run('curl -G --data-urlencode "query=DROP TABLE IF EXISTS ' + table + '" http://localhost:9000/exec', capture_output=True, shell=True)
 
     print("All " + str(runs)+ " runs completed")
 
@@ -210,25 +216,13 @@ def handle_args():
         if args.admin_db_name is None or args.password is None:
             sys.exit("TimeScale needs --admin_db_name and --password")
 
-    if args.workers is None or args.workers <= 0:
-        args.workers = 4
-    else:
-        args.workers = fix_args({"workers": args.workers})
+    args.workers = fix_args({"workers": args.workers})
 
-    if args.runs is None or args.runs <= 0:
-        args.runs = 5
-    else:
-        args.runs = fix_args({"runs": args.runs})
+    args.runs = fix_args({"runs": args.runs})
 
-    if args.scale is None or args.scale <= 0:
-        args.scale = 1000
-    else:
-        args.scale = fix_args({"scale": args.scale})
+    args.scale = fix_args({"scale": args.scale})
 
-    if args.seed is None or args.seed <= 0:
-        args.seed = 123
-    else:
-        args.seed = fix_args({"seed": args.seed})
+    args.seed = fix_args({"seed": args.seed})
 
     if args.timestamp_start is None or not re.findall(r"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ", args.timestamp_start):
         args.timestamp_start = "2025-05-01T00:00:00Z"
@@ -242,6 +236,17 @@ def fix_args(argument_dict):
     try:
         argument = int(list(argument_dict.values())[0])
     except:
+        match list(argument_dict.keys())[0]:
+            case "workers":
+                argument = 4
+            case "runs":
+                argument = 5
+            case "scale":
+                argument = 1000
+            case "seed":
+                argument = 123
+
+    if argument <= 0:
         match list(argument_dict.keys())[0]:
             case "workers":
                 argument = 4


### PR DESCRIPTION
- Added in the drop tables for QuestDB between each run so that it keeps consistent running speed and don't use too much RAM
- Comments and docstrings