### PR TITLE
Removed cpu-only + devops and iot now uses different dates

### DIFF
--- a/tsbs-tests/tsbs_benchmarks.py
+++ b/tsbs-tests/tsbs_benchmarks.py
@@ -291,6 +291,7 @@ def main():
 
     # Creating the different timestamps for use in files
     datestamp = datetime.datetime(2025, 4, 1)
+    start_date = datestamp.__str__().split(" ")[0]
 
     for i in range(args.runs*2):
         date_str = datestamp.__str__().split(" ")[0]
@@ -321,7 +322,7 @@ def main():
 
     avg_dict = create_averages(db_runs_dict)
 
-    avg_dict["metadata"] = {"db_engine": args.format, "scale": args.scale, "seed": args.seed, "workers": args.workers, "runs": args.runs}
+    avg_dict["metadata"] = {"db_engine": args.format, "scale": args.scale, "seed": args.seed, "workers": args.workers, "runs": args.runs, "start_date": start_date}
     
     output_file = "tsbs_" + args.format + "_" + str(args.scale) + ".json"
     

--- a/tsbs-tests/tsbs_benchmarks.py
+++ b/tsbs-tests/tsbs_benchmarks.py
@@ -28,7 +28,7 @@ def generate_data(main_file_path, file_name, db_format, scale, seed, timestamps,
     """
 
     # The use cases for the files
-    use_case = {"devops": "devops", "iot": "iot", "cpu_only": "cpu-only"}
+    use_case = {"devops": "devops", "iot": "iot"}
 
     run_path = main_file_path + "bin/tsbs_generate_data"
     
@@ -260,22 +260,22 @@ def main():
     db_setup = {
     "influx": {
         "db_engine": "influx", 
-        "test_files": ["influx_devops", "influx_iot", "influx_cpu_only"], 
+        "test_files": ["influx_devops", "influx_iot"], 
         "extra_commands": [" --auth-token ", args.auth_token]
         }, 
      "questdb": {
          "db_engine": "questdb", 
-         "test_files": ["questdb_devops", "questdb_iot", "questdb_cpu_only"],
+         "test_files": ["questdb_devops", "questdb_iot"],
          "extra_commands": []
          },
      "timescaledb": {
          "db_engine": "timescaledb",
-         "test_files": ["timescaledb_devops", "timescaledb_iot", "timescaledb_cpu_only"],
+         "test_files": ["timescaledb_devops", "timescaledb_iot"],
          "extra_commands": [" --admin-db-name ", args.admin_db_name, " --pass ", args.password]
          },
      "victoriametrics": {
          "db_engine": "victoriametrics",
-         "test_files": ["victoriametrics_devops", "victoriametrics_iot", "victoriametrics_cpu_only"],
+         "test_files": ["victoriametrics_devops", "victoriametrics_iot"],
          "extra_commands": []
          }
     }
@@ -284,7 +284,7 @@ def main():
     # Default is home folder
     main_file_path = str(pathlib.Path.home()) + "/tsbs/"
     
-    file_name = ["devops", "iot", "cpu_only"]
+    file_name = ["devops", "iot"]
 
     db_runs_dict = {}
     file_number = 0


### PR DESCRIPTION
- Removed cpu-only as it was only a subset of the devops data, it could cause problems since it was using the same timestamps with parts of identical data
- Changed it so devops and iot now runs on seperate dates, right after each other, just in case there was any problems with that