### PR TITLE
Changed to self picked start year and month

### DIFF
--- a/tsbs-tests/tsbs_benchmarks.py
+++ b/tsbs-tests/tsbs_benchmarks.py
@@ -291,12 +291,13 @@ def main():
     timestamps = {}
 
     year_month_list = list(map(int, args.time.split("-")))
-    print(year_month_list)
-    sys.exit(0)
 
     # Creating the different timestamps for use in files
-    datestamp = datetime.datetime(2025, 4, 1)
+    datestamp = datetime.datetime(year_month_list[0], year_month_list[1], 1)
     start_date = datestamp.__str__().split(" ")[0]
+
+    print(start_date)
+    sys.exit(0)
 
     for i in range(args.runs*2):
         date_str = datestamp.__str__().split(" ")[0]

--- a/tsbs-tests/tsbs_benchmarks.py
+++ b/tsbs-tests/tsbs_benchmarks.py
@@ -189,6 +189,7 @@ def handle_args():
     # Arguments for data generation
     parser.add_argument("-s", "--scale", help="The scale for the files, default=1000 for iot and cpu, default=100 for devops", type=int)
     parser.add_argument("-e", "--seed", help="The seed for data generation, same data across all formats, default=123", type=int)
+    parser.add_argument("-t", "--time", help="The start time for the data generation, format YYYY-MM", type=str, required=True)
 
     args = parser.parse_args()
 
@@ -207,6 +208,9 @@ def handle_args():
     args.scale = fix_args({"scale": args.scale})
 
     args.seed = fix_args({"seed": args.seed})
+
+    if not re.findall(r"\d\d\d\d-\d\d", args.time, re.IGNORECASE):
+        args.time = "2025-01"
 
     return args
 
@@ -285,6 +289,10 @@ def main():
     file_number = 0
 
     timestamps = {}
+
+    year_month_list = list(map(int, args.time.split("-")))
+    print(year_month_list)
+    sys.exit(0)
 
     # Creating the different timestamps for use in files
     datestamp = datetime.datetime(2025, 4, 1)

--- a/tsbs-tests/tsbs_benchmarks.py
+++ b/tsbs-tests/tsbs_benchmarks.py
@@ -296,9 +296,6 @@ def main():
     datestamp = datetime.datetime(year_month_list[0], year_month_list[1], 1)
     start_date = datestamp.__str__().split(" ")[0]
 
-    print(start_date)
-    sys.exit(0)
-
     for i in range(args.runs*2):
         date_str = datestamp.__str__().split(" ")[0]
         timestamps[str(i)] = [date_str + "T00:00:00Z", date_str + "T23:59:59Z"]


### PR DESCRIPTION
- Added a new required arg (-t --time) which is year and month for start of run, to make sure no overlapping data from different runs